### PR TITLE
Adding "facilitating" green ellipse to the library

### DIFF
--- a/libraries/nikordaris/team-topologies.excalidrawlib
+++ b/libraries/nikordaris/team-topologies.excalidrawlib
@@ -445,7 +445,35 @@
         "lastCommittedPoint": null,
         "startArrowhead": null,
         "endArrowhead": null
-      }
+      },
+      {
+          "type": "ellipse",
+          "version": 93,
+          "versionNonce": 1894672757,
+          "isDeleted": false,
+          "id": "v4iWLWAyF0vO8swpiZvCL",
+          "fillStyle": "solid",
+          "strokeWidth": 4,
+          "strokeStyle": "dashed",
+          "roughness": 0,
+          "opacity": 30,
+          "angle": 0,
+          "x": 703.0815033783783,
+          "y": 286.08150337837833,
+          "strokeColor": "#087f5b",
+          "backgroundColor": "#82c91e",
+          "width": 201.83699324324334,
+          "height": 201.83699324324334,
+          "seed": 405317636,
+          "groupIds": [],
+          "roundness": {
+            "type": 2
+          },
+          "boundElements": null,
+          "updated": 1673344087740,
+          "link": "",
+          "locked": false
+        }
     ]
   ]
 }


### PR DESCRIPTION
"Facilitating" green elipse from team topologies is missing in the library.